### PR TITLE
feat: update link to WhatsApp for community engagement

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -44,12 +44,12 @@ export default function CommunityPage() {
 						you grow.
 					</p>
 					<a
-						href="https://discord.gg/frontendninjas"
+						href="https://chat.whatsapp.com/KriczFaNCiaDQ14TYzjeKl"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="mt-4 px-4 py-2 sm:px-6 sm:py-3 rounded bg-zinc-900 text-white font-medium hover:bg-zinc-800 transition text-center w-full sm:w-auto"
 					>
-						Join Our Discord
+						Join Our WhatsApp
 					</a>
 				</Card>
 				<div className="w-full max-w-4xl mx-auto mt-10 grid gap-6 sm:gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">


### PR DESCRIPTION
This pull request updates the community page to change the featured social platform from Discord to WhatsApp. The button now links to the WhatsApp group and updates the label accordingly.

- Community platform update:
  * Changed the `href` in the join button from the Discord invite link to a WhatsApp group invite link in `app/community/page.tsx`.
  * Updated the button text from "Join Our Discord" to "Join Our WhatsApp" to reflect the new platform.